### PR TITLE
Fix chroot not working

### DIFF
--- a/rootfs/build_rootfs.sh
+++ b/rootfs/build_rootfs.sh
@@ -25,7 +25,7 @@ echo
 echo "installing prerequisities..."
 echo
 sudo apt install qemu-user-static -y
-sudo cp /usr/bin/qemu-arm-static $ROOT_DIR/usr/bin/
+sudo update-binfmts --enable qemu-arm
 
 # copy our resolv.conf into the armhf rootfs so we have internet when we chroot into it
 sudo cp /etc/resolv.conf $ROOT_DIR/etc/resolv.conf


### PR DESCRIPTION
Suddenly, chrooting into the armhf rootfs was not working in WSL 2 (using the Linux filesystem)
or in Docker on Arch Linux. I don't have a standalone Ubuntu install to test with anymore.

Enabling ARM emulation via `update-binfmts --enable qemu-arm` make chrooting into the armhf rootfs work. I'm not sure why this change is needed, but I suspect it's either a QEMU update or has something to do with switching to Ubuntu 20.04 base for the rootfs. 

Enabling emulation with `update-binfmts` lets QEMU automatically choose which binfmt emulation to use; QEMU uses the host's `qemu-*-static` binaries, so there is no need to copy `qemu-arm-static` to the armhf rootfs anymore. 